### PR TITLE
Updated to use tomcat_user_group

### DIFF
--- a/templates/tomcat.service.j2
+++ b/templates/tomcat.service.j2
@@ -27,7 +27,7 @@ ExecStart={{ tomcat_instance_path }}/bin/startup.sh
 ExecStop={{ tomcat_instance_path }}/bin/shutdown.sh
 
 User={{ tomcat_user_name }}
-Group=tomcat
+Group={{ tomcat_user_group }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
It was hard-coded as tomcat which is an incorrect installation. So this now should populate the correct group

Fixes #12 