### PR TITLE
Add quotes to environment settings for tomcat systemd.

### DIFF
--- a/templates/tomcat.service.j2
+++ b/templates/tomcat.service.j2
@@ -6,19 +6,19 @@ After=network.target
 Type=forking
 
 Restart=on-failure
-Environment=TOMCAT_JAVA_HOME={{ java_home }}
+Environment='TOMCAT_JAVA_HOME={{ java_home }}'
 
 Environment='CATALINA_HOME={{ tomcat_catalina_home }}'
 Environment='CATALINA_BASE={{ tomcat_catalina_home }}'
 
 {% if tomcat_catalina_opts not in (None, "") %}
-Environment=CATALINA_OPTS={{ tomcat_catalina_opts }}
+Environment='CATALINA_OPTS={{ tomcat_catalina_opts }}'
 {% else %}
-Environment=CATALINA_OPTS=-Xms512M -Xmx2048M -server -XX:+UseParallelGC'
+Environment='CATALINA_OPTS=-Xms512M -Xmx2048M -server -XX:+UseParallelGC'
 {% endif %}
 
 {% if tomcat_java_opts not in (None, "") %}
-Environment=JAVA_OPTS={{ tomcat_java_opts }}
+Environment='JAVA_OPTS={{ tomcat_java_opts }}'
 {% else %}
 Environment='JAVA_OPTS=-Djava.awt.headless=true'
 {% endif %}


### PR DESCRIPTION
Hi there,

Nice work! I'm trying to run your ansible roles on SuSE SLES 12 SP1. 

However, I need to add quotes to enclose the tomcat environment settings or I would get following error:

`Mar 20 08:36:43 sles systemd[1]: [/etc/systemd/system/tomcat.service:14] Invalid environment assignment, ignoring: CATALINA_OPTS=-Xms512M -Xmx2048M -server -XX:+UseParallelGC'`

Cheers,
KM