### PR TITLE
Apache Portable Runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -188,6 +188,7 @@ before_install:
 install:
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-galaxy install ChristopherDavenport.universal-java'
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-galaxy install ChristopherDavenport.apache-portable-runtime'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-galaxy install ChristopherDavenport.openssl'
 
 script:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,19 @@ services:
 
 env:
   global:
-  - SYSTEMD_OPTS: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - ANSIBLE_ROLE_LOCATION: "/etc/ansible/roles/role_under_test"
+    - SYSTEMD_OPTS: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - ANSIBLE_ROLE_LOCATION: "/etc/ansible/roles/role_under_test"
+    - playbook: test.yml
   matrix:
+#### No APR Checks
+  - distribution: Ubuntu
+    distribution_version: xenial
+    version: "8.5.12"
+    init: /lib/systemd/systemd
+    run_opts: "${SYSTEMD_OPTS}"
+    playbook: no_apr.yml
+
+
 # Stable Release Versions - 8.5
 # SystemD
   - distribution: Ubuntu
@@ -182,6 +192,8 @@ env:
 #    init: /sbin/init
 #    run_opts: ""
 
+
+
 before_install:
   # Pull container.
   - 'docker pull ansiblecheck/ansiblecheck:${distribution,,}-${distribution_version}'
@@ -195,14 +207,14 @@ install:
 script:
 
   # Ansible syntax check.
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook ${ANSIBLE_ROLE_LOCATION}/tests/test.yml --syntax-check'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook ${ANSIBLE_ROLE_LOCATION}/tests/${playbook} --syntax-check'
 
   # Test role.
-  - 'docker exec "$(cat ${container_id})" ansible-playbook ${ANSIBLE_ROLE_LOCATION}/tests/test.yml --extra-vars "tomcat_version=${version}"'
+  - 'docker exec "$(cat ${container_id})" ansible-playbook ${ANSIBLE_ROLE_LOCATION}/tests/${playbook} --extra-vars "tomcat_version=${version}"'
 
   # Test Idempotence
   - idempotence=$(mktemp)
-  - docker exec "$(cat ${container_id})" ansible-playbook ${ANSIBLE_ROLE_LOCATION}/tests/test.yml --extra-vars "tomcat_version=${version}" | tee -a ${idempotence}
+  - docker exec "$(cat ${container_id})" ansible-playbook ${ANSIBLE_ROLE_LOCATION}/tests/${playbook} --extra-vars "tomcat_version=${version}" | tee -a ${idempotence}
   - >
     tail ${idempotence}
     | grep -q 'changed=0.*failed=0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,6 @@ env:
     - ANSIBLE_ROLE_LOCATION: "/etc/ansible/roles/role_under_test"
     - playbook: test.yml
   matrix:
-#### No APR Checks
-  - distribution: Ubuntu
-    distribution_version: xenial
-    version: "8.5.12"
-    init: /lib/systemd/systemd
-    run_opts: "${SYSTEMD_OPTS}"
-    playbook: no_apr.yml
-
 
 # Stable Release Versions - 8.5
 # SystemD
@@ -38,27 +30,6 @@ env:
     version: "8.5.12"
     init: /usr/lib/systemd/systemd
     run_opts: "${SYSTEMD_OPTS}"
-# Init
-#  - distribution: Ubuntu
-#    distribution_version: trusty
-#    version: "8.5.12"
-#    init: /sbin/init
-#    run_opts: ""
-#  - distribution: Ubuntu
-#    distribution_version: precise
-#    version: "8.5.12"
-#    init: /sbin/init
-#    run_opts: ""
-#  - distribution: EL
-#    distribution_version: "6"
-#    version: "8.5.12"
-#    init: /sbin/init
-#    run_opts: ""
-#  - distribution: OracleLinux
-#    distribution_version: "6"
-#    version: "8.5.12"
-#    init: /sbin/init
-#    run_opts: ""
 
 # Tomcat 8.0 - now superseded by 8.5
 # SystemD
@@ -82,27 +53,6 @@ env:
     version: "8.0.42"
     init: /usr/lib/systemd/systemd
     run_opts: "${SYSTEMD_OPTS}"
-# Init
-#  - distribution: Ubuntu
-#    distribution_version: trusty
-#    version: "8.0.42"
-#    init: /sbin/init
-#    run_opts: ""
-#  - distribution: Ubuntu
-#    distribution_version: precise
-#    version: "8.0.42"
-#    init: /sbin/init
-#    run_opts: ""
-#  - distribution: EL
-#    distribution_version: "6"
-#    version: "8.0.42"
-#    init: /sbin/init
-#    run_opts: ""
-#  - distribution: OracleLinux
-#    distribution_version: "6"
-#    version: "8.0.42"
-#    init: /sbin/init
-#    run_opts: ""
 
 # Tomcat 7 Support
 # SystemD
@@ -126,27 +76,6 @@ env:
     version: "7.0.76"
     init: /usr/lib/systemd/systemd
     run_opts: "${SYSTEMD_OPTS}"
-# Init
-#  - distribution: Ubuntu
-#    distribution_version: trusty
-#    version: "7.0.76"
-#    init: /sbin/init
-#    run_opts: ""
-#  - distribution: Ubuntu
-#    distribution_version: precise
-#    version: "7.0.76"
-#    init: /sbin/init
-#    run_opts: ""
-#  - distribution: EL
-#    distribution_version: "6"
-#    version: "7.0.76"
-#    init: /sbin/init
-#    run_opts: ""
-#  - distribution: OracleLinux
-#    distribution_version: "6"
-#    version: "7.0.76"
-#    init: /sbin/init
-#    run_opts: ""
 
 # Tomcat 9 Current Milestone
 # SystemD
@@ -170,29 +99,34 @@ env:
     version: "9.0.0.M18"
     init: /usr/lib/systemd/systemd
     run_opts: "${SYSTEMD_OPTS}"
-# Init
-#  - distribution: Ubuntu
-#    distribution_version: trusty
-#    version: "9.0.0.M18"
-#    init: /sbin/init
-#    run_opts: ""
-#  - distribution: Ubuntu
-#    distribution_version: precise
-#    version: "9.0.0.M18"
-#    init: /sbin/init
-#    run_opts: ""
-#  - distribution: EL
-#    distribution_version: "6"
-#    version: "9.0.0.M18"
-#    init: /sbin/init
-#    run_opts: ""
-#  - distribution: OracleLinux
-#    distribution_version: "6"
-#    version: "9.0.0.M18"
-#    init: /sbin/init
-#    run_opts: ""
 
-
+# NO APR Installations
+# Stable Release Versions - 8.5
+# SystemD
+  - distribution: Ubuntu
+    distribution_version: xenial
+    version: "8.5.12"
+    init: /lib/systemd/systemd
+    run_opts: "${SYSTEMD_OPTS}"
+    playbook: no_apr.yml
+  - distribution: EL
+    distribution_version: "7"
+    version: "8.5.12"
+    init: /usr/lib/systemd/systemd
+    run_opts: "${SYSTEMD_OPTS}"
+    playbook: no_apr.yml
+  - distribution: Fedora
+    distribution_version: "23"
+    version: "8.5.12"
+    init: /usr/lib/systemd/systemd
+    run_opts: "${SYSTEMD_OPTS}"
+    playbook: no_apr.yml
+  - distribution: OracleLinux
+    distribution_version: "7"
+    version: "8.5.12"
+    init: /usr/lib/systemd/systemd
+    run_opts: "${SYSTEMD_OPTS}"
+    playbook: no_apr.yml
 
 before_install:
   # Pull container.

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,28 +2,32 @@ services:
   - docker
 
 env:
+  global:
+  - SYSTEMD_OPTS: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - ANSIBLE_ROLE_LOCATION: "/etc/ansible/roles/role_under_test"
+  matrix:
 # Stable Release Versions - 8.5
 # SystemD
   - distribution: Ubuntu
     distribution_version: xenial
     version: "8.5.12"
     init: /lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
   - distribution: EL
     distribution_version: "7"
     version: "8.5.12"
     init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
   - distribution: Fedora
     distribution_version: "23"
     version: "8.5.12"
     init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
   - distribution: OracleLinux
     distribution_version: "7"
     version: "8.5.12"
     init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
 # Init
 #  - distribution: Ubuntu
 #    distribution_version: trusty
@@ -52,22 +56,22 @@ env:
     distribution_version: xenial
     version: "8.0.42"
     init: /lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
   - distribution: EL
     distribution_version: "7"
     version: "8.0.42"
     init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
   - distribution: Fedora
     distribution_version: "23"
     version: "8.0.42"
     init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
   - distribution: OracleLinux
     distribution_version: "7"
     version: "8.0.42"
     init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
 # Init
 #  - distribution: Ubuntu
 #    distribution_version: trusty
@@ -96,22 +100,22 @@ env:
     distribution_version: xenial
     version: "7.0.76"
     init: /lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
   - distribution: EL
     distribution_version: "7"
     version: "7.0.76"
     init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
   - distribution: Fedora
     distribution_version: "23"
     version: "7.0.76"
     init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
   - distribution: OracleLinux
     distribution_version: "7"
     version: "7.0.76"
     init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
 # Init
 #  - distribution: Ubuntu
 #    distribution_version: trusty
@@ -140,22 +144,22 @@ env:
     distribution_version: xenial
     version: "9.0.0.M18"
     init: /lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
   - distribution: EL
     distribution_version: "7"
     version: "9.0.0.M18"
     init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
   - distribution: Fedora
     distribution_version: "23"
     version: "9.0.0.M18"
     init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
   - distribution: OracleLinux
     distribution_version: "7"
     version: "9.0.0.M18"
     init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: "${SYSTEMD_OPTS}"
 # Init
 #  - distribution: Ubuntu
 #    distribution_version: trusty
@@ -183,24 +187,22 @@ before_install:
   - 'docker pull ansiblecheck/ansiblecheck:${distribution,,}-${distribution_version}'
   - container_id=$(mktemp)
   # Start The Built Container In The Background
-  - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_version}" "${init}" > "${container_id}"'
+  - 'docker run --detach --volume="${PWD}":${ANSIBLE_ROLE_LOCATION}:ro ${run_opts} ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_version}" "${init}" > "${container_id}"'
 
 install:
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-galaxy install ChristopherDavenport.universal-java'
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-galaxy install ChristopherDavenport.apache-portable-runtime'
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-galaxy install ChristopherDavenport.openssl'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-galaxy install ${ANSIBLE_ROLE_LOCATION}/requirements.yml'
 
 script:
 
   # Ansible syntax check.
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook ${ANSIBLE_ROLE_LOCATION}/tests/test.yml --syntax-check'
 
   # Test role.
-  - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --extra-vars "tomcat_version=${version}"'
+  - 'docker exec "$(cat ${container_id})" ansible-playbook ${ANSIBLE_ROLE_LOCATION}/tests/test.yml --extra-vars "tomcat_version=${version}"'
 
   # Test Idempotence
   - idempotence=$(mktemp)
-  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --extra-vars "tomcat_version=${version}" | tee -a ${idempotence}
+  - docker exec "$(cat ${container_id})" ansible-playbook ${ANSIBLE_ROLE_LOCATION}/tests/test.yml --extra-vars "tomcat_version=${version}" | tee -a ${idempotence}
   - >
     tail ${idempotence}
     | grep -q 'changed=0.*failed=0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -190,7 +190,7 @@ before_install:
   - 'docker run --detach --volume="${PWD}":${ANSIBLE_ROLE_LOCATION}:ro ${run_opts} ansiblecheck/ansiblecheck:"${distribution,,}"-"${distribution_version}" "${init}" > "${container_id}"'
 
 install:
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-galaxy install ${ANSIBLE_ROLE_LOCATION}/requirements.yml'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-galaxy install -r ${ANSIBLE_ROLE_LOCATION}/requirements.yml'
 
 script:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -187,6 +187,7 @@ before_install:
 
 install:
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-galaxy install ChristopherDavenport.universal-java'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-galaxy install ChristopherDavenport.apache-portable-runtime'
 
 script:
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ This is a system for installing and managing tomcat configurations.
 Requirements
 ------------
 
+None
+
 Role Dependencies
 -----------------
 
-[ChristopherDavenport.universal-java](https://galaxy.ansible.com/ChristopherDavenport/universal-java/)
+[ChristopherDavenport.universal-java](https://galaxy.ansible.com/ChristopherDavenport/universal-java/)  
 [ChristopherDavenport.apache-portable-runtime](https://galaxy.ansible.com/ChristopherDavenport/apache-portable-runtime/) - Contingent on `tomcat_use_apr` variable.
 
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Requirements
 ------------
 
 Role Dependencies
+-----------------
+
+[ChristopherDavenport.universal-java](https://galaxy.ansible.com/ChristopherDavenport/universal-java/)
+[ChristopherDavenport.apache-portable-runtime](https://galaxy.ansible.com/ChristopherDavenport/apache-portable-runtime/) - Contingent on `tomcat_use_apr` variable.
+
 
 Role Variables
 --------------
@@ -18,18 +23,25 @@ Role Variables
 
 # Tomcat versions available
 # 6.0.47
+# 6.0.51
 # 7.0.72
+# 7.0.76
 # 8.0.38
+# 8.0.42
 # 8.5.6
-# 9.0.0.M11
+# 8.5.12
+# 9.0.0.M18
 
-tomcat_version: "8.5.6"
+tomcat_version: "8.5.12"
 
 tomcat_mirrors:
   - http://archive.apache.org/dist/tomcat
 
 # Temporary Storage Directory
 tomcat_tmp_storage: /tmp/tomcat-ansible
+
+# Variable That Decides To Install the APR Role Dependency
+tomcat_use_apr: true
 
 tomcat_user_name: tomcat
 tomcat_user_group: tomcat
@@ -69,6 +81,8 @@ tomcat_users: []
   #   roles: "manager-gui,admin-gui"
   #
 
+tomcat_debug: false
+
 # This Edits And Allows Ansible To Configure These
 # Otherwise it does a default install
 tomcat_configure: true
@@ -77,7 +91,7 @@ tomcat_configure_libs: "{{ tomcat_configure }}"
 tomcat_configure_webapps: "{{ tomcat_configure }}"
 
 # These copy files across and will use basename
-tomcat_extra_libs_path: ""
+tomcat_extra_libs_path: []
 tomcat_webapps_path: []
 
 # Strings That Allow you to modify your
@@ -91,7 +105,6 @@ tomcat_context_xml_extra: ""
 tomcat_disable_persistence_across_restarts: false
 
 # Custom Configuration Files
-# Use these to use custom xml files
 tomcat_use_custom_server_xml: false
 # tomcat_custom_server_xml: Path
 tomcat_use_custom_web_xml: false
@@ -102,13 +115,66 @@ tomcat_use_custom_tomcat_users_xml: false
 # tomcat_custom_tomcat_users_xml: Path
 tomcat_use_custom_manager_context_xml: false
 # tomcat_custom_manager_context_xml: Path
+
+# Tomcat major version
+tomcat_version_major: "{{ tomcat_version.0 }}"
+tomcat_tar_archive: "apache-tomcat-{{ tomcat_version }}.tar.gz"
+
+tomcat_instance_directories:
+  - conf
+  - logs
+  - webapps
+  - temp
+  - bin
+  - lib
+  - work
+
+tomcat_version_specific:
+  "6.0.47":
+    checksum: md5:7b848f76b605c0fd7fd5c7291a050ca4
+    web_xml_schema_version: 3.0
+    tomcat_native_version: "1.2.10"
+  "6.0.51":
+    checksum: md5:c18a8f0cb5966d3f599d49cafeaf7c54
+    web_xml_schema_version: 3.0
+    tomcat_native_version: "1.2.12"
+  "7.0.72":
+    checksum: md5:c24bfae15bb9c510451a05582aae634d
+    web_xml_schema_version: 3.0
+    tomcat_native_version: "1.2.10"
+  "7.0.76":
+    checksum: md5:ae2e481f918eb2a99a0e47a07e5f1671
+    web_xml_schema_version: 3.0
+    tomcat_native_version: "1.2.12"
+  "8.0.24":
+    checksum: md5:9f71353dfba0184c23ecd4743e4132ff
+    web_xml_schema_version: 3.1
+    tomcat_native_version: "1.2.10"
+  "8.0.38":
+    checksum: md5:cb1f5e098024df2bb19c581eca180a2a
+    web_xml_schema_version: 3.1
+    tomcat_native_version: "1.2.12"
+  "8.0.42":
+    checksum: md5:3cabfc2d3c320b7eb62f8a94da0447ea
+    web_xml_schema_version: 3.1
+    tomcat_native_version: "1.2.12"
+  "8.5.6":
+    checksum: md5:e273e27deb1828ae5f19374616b9fba8
+    web_xml_schema_version: 3.1
+    tomcat_native_version: "1.2.10"
+  "8.5.12":
+    checksum: md5:c2e6eca5a0642d1e30fbe3573b96ab75
+    web_xml_schema_version: 3.1
+    tomcat_native_version: "1.2.12"
+  "9.0.0.M18":
+    checksum: md5:626e16b93de65b2a58714ed50f00d9f9
+    web_xml_schema_version: 3.1
+    tomcat_native_version: "1.2.12"
 ```
 
 
 Dependencies
 ------------
-
-[ChristopherDavenport.universal-java](https://github.com/ChristopherDavenport/ansible-role-universal-java)
 
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,40 +104,40 @@ tomcat_version_specific:
   "6.0.47":
     checksum: md5:7b848f76b605c0fd7fd5c7291a050ca4
     web_xml_schema_version: 3.0
-    tomcat_native_version: 1.2.10
+    tomcat_native_version: "1.2.10"
   "6.0.51":
     checksum: md5:c18a8f0cb5966d3f599d49cafeaf7c54
     web_xml_schema_version: 3.0
-    tomcat_native_version: 1.2.12
+    tomcat_native_version: "1.2.12"
   "7.0.72":
     checksum: md5:c24bfae15bb9c510451a05582aae634d
     web_xml_schema_version: 3.0
-    tomcat_native_version: 1.2.10
+    tomcat_native_version: "1.2.10"
   "7.0.76":
     checksum: md5:ae2e481f918eb2a99a0e47a07e5f1671
     web_xml_schema_version: 3.0
-    tomcat_native_version: 1.2.12
+    tomcat_native_version: "1.2.12"
   "8.0.24":
     checksum: md5:9f71353dfba0184c23ecd4743e4132ff
     web_xml_schema_version: 3.1
-    tomcat_native_version: 1.2.10
+    tomcat_native_version: "1.2.10"
   "8.0.38":
     checksum: md5:cb1f5e098024df2bb19c581eca180a2a
     web_xml_schema_version: 3.1
-    tomcat_native_version: 1.2.12
+    tomcat_native_version: "1.2.12"
   "8.0.42":
     checksum: md5:3cabfc2d3c320b7eb62f8a94da0447ea
     web_xml_schema_version: 3.1
-    tomcat_native_version: 1.2.12
+    tomcat_native_version: "1.2.12"
   "8.5.6":
     checksum: md5:e273e27deb1828ae5f19374616b9fba8
     web_xml_schema_version: 3.1
-    tomcat_native_version: 1.2.10
+    tomcat_native_version: "1.2.10"
   "8.5.12":
     checksum: md5:c2e6eca5a0642d1e30fbe3573b96ab75
     web_xml_schema_version: 3.1
-    tomcat_native_version: 1.2.12
+    tomcat_native_version: "1.2.12"
   "9.0.0.M18":
     checksum: md5:626e16b93de65b2a58714ed50f00d9f9
     web_xml_schema_version: 3.1
-    tomcat_native_version: 1.2.12
+    tomcat_native_version: "1.2.12"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,8 @@ tomcat_users: []
   #   roles: "manager-gui,admin-gui"
   #
 
+tomcat_debug: false
+
 # This Edits And Allows Ansible To Configure These
 # Otherwise it does a default install
 tomcat_configure: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,8 @@ tomcat_mirrors:
 # Temporary Storage Directory
 tomcat_tmp_storage: /tmp/tomcat-ansible
 
+tomcat_use_apr: true
+
 tomcat_user_name: tomcat
 tomcat_user_group: tomcat
 tomcat_user_home: /home/{{ tomcat_user_name }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,12 +3,16 @@
 
 # Tomcat versions available
 # 6.0.47
+# 6.0.51
 # 7.0.72
+# 7.0.76
 # 8.0.38
+# 8.0.42
 # 8.5.6
+# 8.5.12
 # 9.0.0.M18
 
-tomcat_version: "8.5.6"
+tomcat_version: "8.5.12"
 
 tomcat_mirrors:
   - http://archive.apache.org/dist/tomcat
@@ -16,6 +20,7 @@ tomcat_mirrors:
 # Temporary Storage Directory
 tomcat_tmp_storage: /tmp/tomcat-ansible
 
+# Variable That Decides To Install the APR Role Dependency
 tomcat_use_apr: true
 
 tomcat_user_name: tomcat

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,30 +104,40 @@ tomcat_version_specific:
   "6.0.47":
     checksum: md5:7b848f76b605c0fd7fd5c7291a050ca4
     web_xml_schema_version: 3.0
+    tomcat_native_version: "1.2.10"
   "6.0.51":
     checksum: md5:c18a8f0cb5966d3f599d49cafeaf7c54
     web_xml_schema_version: 3.0
+    tomcat_native_version: "1.2.12"
   "7.0.72":
     checksum: md5:c24bfae15bb9c510451a05582aae634d
     web_xml_schema_version: 3.0
+    tomcat_native_version: "1.2.10"
   "7.0.76":
     checksum: md5:ae2e481f918eb2a99a0e47a07e5f1671
     web_xml_schema_version: 3.0
+    tomcat_native_version: "1.2.12"
   "8.0.24":
     checksum: md5:9f71353dfba0184c23ecd4743e4132ff
     web_xml_schema_version: 3.1
+    tomcat_native_version: "1.2.10"
   "8.0.38":
     checksum: md5:cb1f5e098024df2bb19c581eca180a2a
     web_xml_schema_version: 3.1
+    tomcat_native_version: "1.2.12"
   "8.0.42":
     checksum: md5:3cabfc2d3c320b7eb62f8a94da0447ea
     web_xml_schema_version: 3.1
+    tomcat_native_version: "1.2.12"
   "8.5.6":
     checksum: md5:e273e27deb1828ae5f19374616b9fba8
     web_xml_schema_version: 3.1
+    tomcat_native_version: "1.2.10"
   "8.5.12":
     checksum: md5:c2e6eca5a0642d1e30fbe3573b96ab75
     web_xml_schema_version: 3.1
+    tomcat_native_version: "1.2.12"
   "9.0.0.M18":
     checksum: md5:626e16b93de65b2a58714ed50f00d9f9
     web_xml_schema_version: 3.1
+    tomcat_native_version: "1.2.12"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,40 +104,40 @@ tomcat_version_specific:
   "6.0.47":
     checksum: md5:7b848f76b605c0fd7fd5c7291a050ca4
     web_xml_schema_version: 3.0
-    tomcat_native_version: "1.2.10"
+    tomcat_native_version: 1.2.10
   "6.0.51":
     checksum: md5:c18a8f0cb5966d3f599d49cafeaf7c54
     web_xml_schema_version: 3.0
-    tomcat_native_version: "1.2.12"
+    tomcat_native_version: 1.2.12
   "7.0.72":
     checksum: md5:c24bfae15bb9c510451a05582aae634d
     web_xml_schema_version: 3.0
-    tomcat_native_version: "1.2.10"
+    tomcat_native_version: 1.2.10
   "7.0.76":
     checksum: md5:ae2e481f918eb2a99a0e47a07e5f1671
     web_xml_schema_version: 3.0
-    tomcat_native_version: "1.2.12"
+    tomcat_native_version: 1.2.12
   "8.0.24":
     checksum: md5:9f71353dfba0184c23ecd4743e4132ff
     web_xml_schema_version: 3.1
-    tomcat_native_version: "1.2.10"
+    tomcat_native_version: 1.2.10
   "8.0.38":
     checksum: md5:cb1f5e098024df2bb19c581eca180a2a
     web_xml_schema_version: 3.1
-    tomcat_native_version: "1.2.12"
+    tomcat_native_version: 1.2.12
   "8.0.42":
     checksum: md5:3cabfc2d3c320b7eb62f8a94da0447ea
     web_xml_schema_version: 3.1
-    tomcat_native_version: "1.2.12"
+    tomcat_native_version: 1.2.12
   "8.5.6":
     checksum: md5:e273e27deb1828ae5f19374616b9fba8
     web_xml_schema_version: 3.1
-    tomcat_native_version: "1.2.10"
+    tomcat_native_version: 1.2.10
   "8.5.12":
     checksum: md5:c2e6eca5a0642d1e30fbe3573b96ab75
     web_xml_schema_version: 3.1
-    tomcat_native_version: "1.2.12"
+    tomcat_native_version: 1.2.12
   "9.0.0.M18":
     checksum: md5:626e16b93de65b2a58714ed50f00d9f9
     web_xml_schema_version: 3.1
-    tomcat_native_version: "1.2.12"
+    tomcat_native_version: 1.2.12

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,4 +30,4 @@ galaxy_info:
 
 dependencies:
   - ChristopherDavenport.universal-java
-  - ChristopherDavenport.apache-portable-runtime
+  - { role: ChristopherDavenport.apache-portable-runtime, when: tomcat_use_apr }

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,5 +30,4 @@ galaxy_info:
 
 dependencies:
   - ChristopherDavenport.universal-java
-  - ChristopherDavenport.openssl
   - ChristopherDavenport.apache-portable-runtime

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -31,3 +31,4 @@ galaxy_info:
 dependencies:
   - ChristopherDavenport.universal-java
   - ChristopherDavenport.apache-portable-runtime
+  - ChristopherDavenport.openssl

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,3 +30,4 @@ galaxy_info:
 
 dependencies:
   - ChristopherDavenport.universal-java
+  - ChristopherDavenport.apache-portable-runtime

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,5 +30,5 @@ galaxy_info:
 
 dependencies:
   - ChristopherDavenport.universal-java
-  - ChristopherDavenport.apache-portable-runtime
   - ChristopherDavenport.openssl
+  - ChristopherDavenport.apache-portable-runtime

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,4 @@
+---
+
+- src: ChristopherDavenport.universal-java
+- src: ChristopherDavenport.apache-portable-runtime

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -189,6 +189,60 @@
     group: "{{ tomcat_user_group }}"
     mode: 0755
 
+- name: Install Apache Portable Runtime Integration
+  unarchive:
+    remote_src: yes
+    src: "{{ tomcat_instance_path }}/bin/tomcat-native.tar.gz"
+    dest: "{{ tomcat_instance_path }}/bin"
+    keep_newer: yes
+
+- name: Ouput Files
+  register: __tomcat_bin_files
+  command: >
+    ls
+    chdir="{{ tomcat_instance_path }}/bin"
+
+- debug: var=__tomcat_bin_files.stdout_lines
+
+- name: Configure APR
+  # when: not __apr_installed
+  register: __apr_configure
+  command: >
+    ./configure --with-apr=/usr/local/apr --with-java-home={{ java_home }}
+    chdir="{{ tomcat_instance_path }}/bin/tomcat-native-1.2.10-src"
+
+- name: Debug Output of APR Configure
+  debug: var=__apr_configure.stdout_lines
+  # when:
+  #   - apr_debug
+  #   - not __apr_installed
+
+- name: Make APR
+  # when: not __apr_installed
+  register: __apr_make
+  make:
+    chdir: "{{ tomcat_instance_path }}/bin/tomcat-native-1.2.10-src"
+
+- name: Debug Output of Make APR
+  debug: var=__apr_make.stdout_lines
+  # when:
+  #   - apr_debug
+  #   - not __apr_installed
+
+- name: Make Install APR
+  # when: not __apr_installed
+  register: __apr_make_install
+  make:
+    chdir: "{{ tomcat_instance_path }}/bin/tomcat-native-1.2.10-src"
+    target: install
+  become: yes
+
+- name: Debug Output of Make Install APR
+  debug: var=__apr_make_install.stdout_lines
+  # when:
+  #   - apr_debug
+  #   - not __apr_installed
+
 - name: Check if systemd is present
   stat:
     path: "/sbin/init"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -213,7 +213,7 @@
   register: __tomcat_apr_configure
   command: >
     ./configure
-    --with-apr=/usr/local/apr
+    --with-apr={{ apr_install_location }}
     --with-java-home={{ java_home }}
     --with-ssl={{ openssl_install_location }}
     --prefix={{ tomcat_catalina_home }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -236,6 +236,7 @@
 - name: Debug Output of Make APR
   debug: var=__tomcat_apr_make.stdout_lines
   when:
+    - tomcat_use_apr
     - tomcat_debug
     - not __tomcat_apr_dir.stat.exists
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -204,41 +204,47 @@
 
 - debug: var=__tomcat_bin_files.stdout_lines
 
+- name: Set Unpacked Dir Location
+  set_fact:
+    __tomcat_native_unpacked_dir: "{{tomcat_instance_path}}/bin/tomcat-native-{{ tomcat_version_specific[tomcat_version].tomcat_native_version }}-src"
+
+- debug: var=__tomcat_native_unpacked_dir
+
 - name: Configure APR
   # when: not __apr_installed
-  register: __apr_configure
+  register: __tomcat_apr_configure
   command: >
     ./configure --with-apr=/usr/local/apr --with-java-home={{ java_home }}
-    chdir="{{ tomcat_instance_path }}/bin/tomcat-native-{{ tomcat_version_specific[tomcat_version].tomcat_native_version }}-src"
+    chdir="{{ __tomcat_native_unpacked_dir }}"
 
 - name: Debug Output of APR Configure
-  debug: var=__apr_configure.stdout_lines
+  debug: var=__tomcat_apr_configure.stdout_lines
   # when:
   #   - apr_debug
   #   - not __apr_installed
 
 - name: Make APR
   # when: not __apr_installed
-  register: __apr_make
+  register: __tomcat_apr_make
   make:
-    chdir: "{{ tomcat_instance_path }}/bin/tomcat-native-{{ tomcat_version_specific[tomcat_version].tomcat_native_version }}-src"
+    chdir: "{{ __tomcat_native_unpacked_dir }}"
 
 - name: Debug Output of Make APR
-  debug: var=__apr_make.stdout_lines
+  debug: var=__tomcat_apr_make.stdout_lines
   # when:
   #   - apr_debug
   #   - not __apr_installed
 
 - name: Make Install APR
   # when: not __apr_installed
-  register: __apr_make_install
+  register: __tomcat_apr_make_install
   make:
-    chdir: "{{ tomcat_instance_path }}/bin/tomcat-native-{{ tomcat_version_specific[tomcat_version].tomcat_native_version }}-src"
+    chdir: "{{ __tomcat_native_unpacked_dir }}"
     target: install
   become: yes
 
 - name: Debug Output of Make Install APR
-  debug: var=__apr_make_install.stdout_lines
+  debug: var=__tomcat_apr_make_install.stdout_lines
   # when:
   #   - apr_debug
   #   - not __apr_installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -189,29 +189,27 @@
     group: "{{ tomcat_user_group }}"
     mode: 0755
 
+- name: Set Unpacked APR Directory Location
+  set_fact:
+    __tomcat_native_unpacked_dir: "{{tomcat_instance_path}}/bin/tomcat-native-{{ tomcat_version_specific[tomcat_version].tomcat_native_version }}-src/native"
+
+- name: Check If APR Installed
+  stat:
+    path: "{{ __tomcat_native_unpacked_dir }}"
+  register: __tomcat_apr_dir
+
+
 - name: Install Apache Portable Runtime Integration
+  when: not __tomcat_apr_dir.stat.exists
   unarchive:
     remote_src: yes
     src: "{{ tomcat_instance_path }}/bin/tomcat-native.tar.gz"
     dest: "{{ tomcat_instance_path }}/bin"
     keep_newer: yes
 
-- name: Set Unpacked Dir Location
-  set_fact:
-    __tomcat_native_unpacked_dir: "{{tomcat_instance_path}}/bin/tomcat-native-{{ tomcat_version_specific[tomcat_version].tomcat_native_version }}-src/native"
-
-- debug: var=__tomcat_native_unpacked_dir
-
-- name: Ouput Files
-  register: __tomcat_bin_files
-  command: >
-    ls
-    chdir={{ __tomcat_native_unpacked_dir }}
-
-- debug: var=__tomcat_bin_files.stdout_lines
 
 - name: Configure APR
-  # when: not __apr_installed
+  when: not __tomcat_apr_dir.stat.exists
   register: __tomcat_apr_configure
   command: >
     ./configure --with-apr=/usr/local/apr --with-java-home={{ java_home }}
@@ -219,24 +217,24 @@
 
 - name: Debug Output of APR Configure
   debug: var=__tomcat_apr_configure.stdout_lines
-  # when:
-  #   - apr_debug
-  #   - not __apr_installed
+  when:
+    - tomcat_debug
+    - not __tomcat_apr_dir.stat.exists
 
 - name: Make APR
-  # when: not __apr_installed
+  when: not __tomcat_apr_dir.stat.exists
   register: __tomcat_apr_make
   make:
     chdir: "{{ __tomcat_native_unpacked_dir }}"
 
 - name: Debug Output of Make APR
   debug: var=__tomcat_apr_make.stdout_lines
-  # when:
-  #   - apr_debug
-  #   - not __apr_installed
+  when:
+    - tomcat_debug
+    - not __tomcat_apr_dir.stat.exists
 
 - name: Make Install APR
-  # when: not __apr_installed
+  when: not __tomcat_apr_dir.stat.exists
   register: __tomcat_apr_make_install
   make:
     chdir: "{{ __tomcat_native_unpacked_dir }}"
@@ -245,9 +243,9 @@
 
 - name: Debug Output of Make Install APR
   debug: var=__tomcat_apr_make_install.stdout_lines
-  # when:
-  #   - apr_debug
-  #   - not __apr_installed
+  when:
+    - tomcat_debug
+    - not __tomcat_apr_dir.stat.exists
 
 - name: Check if systemd is present
   stat:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -196,26 +196,26 @@
     dest: "{{ tomcat_instance_path }}/bin"
     keep_newer: yes
 
-- name: Ouput Files
-  register: __tomcat_bin_files
-  command: >
-    ls
-    chdir="{{ tomcat_instance_path }}/bin"
-
-- debug: var=__tomcat_bin_files.stdout_lines
-
 - name: Set Unpacked Dir Location
   set_fact:
     __tomcat_native_unpacked_dir: "{{tomcat_instance_path}}/bin/tomcat-native-{{ tomcat_version_specific[tomcat_version].tomcat_native_version }}-src"
 
 - debug: var=__tomcat_native_unpacked_dir
 
+- name: Ouput Files
+  register: __tomcat_bin_files
+  command: >
+    ls
+    chdir={{ __tomcat_native_unpacked_dir }}
+
+- debug: var=__tomcat_bin_files.stdout_lines
+
 - name: Configure APR
   # when: not __apr_installed
   register: __tomcat_apr_configure
   command: >
     ./configure --with-apr=/usr/local/apr --with-java-home={{ java_home }}
-    chdir="{{ __tomcat_native_unpacked_dir }}"
+    chdir={{ __tomcat_native_unpacked_dir }}
 
 - name: Debug Output of APR Configure
   debug: var=__tomcat_apr_configure.stdout_lines

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -209,7 +209,7 @@
   register: __apr_configure
   command: >
     ./configure --with-apr=/usr/local/apr --with-java-home={{ java_home }}
-    chdir="{{ tomcat_instance_path }}/bin/tomcat-native-1.2.10-src"
+    chdir="{{ tomcat_instance_path }}/bin/tomcat-native-{{ tomcat_version_specific[tomcat_version].tomcat_native_version }}-src"
 
 - name: Debug Output of APR Configure
   debug: var=__apr_configure.stdout_lines
@@ -221,7 +221,7 @@
   # when: not __apr_installed
   register: __apr_make
   make:
-    chdir: "{{ tomcat_instance_path }}/bin/tomcat-native-1.2.10-src"
+    chdir: "{{ tomcat_instance_path }}/bin/tomcat-native-{{ tomcat_version_specific[tomcat_version].tomcat_native_version }}-src"
 
 - name: Debug Output of Make APR
   debug: var=__apr_make.stdout_lines
@@ -233,7 +233,7 @@
   # when: not __apr_installed
   register: __apr_make_install
   make:
-    chdir: "{{ tomcat_instance_path }}/bin/tomcat-native-1.2.10-src"
+    chdir: "{{ tomcat_instance_path }}/bin/tomcat-native-{{ tomcat_version_specific[tomcat_version].tomcat_native_version }}-src"
     target: install
   become: yes
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -198,7 +198,7 @@
 
 - name: Set Unpacked Dir Location
   set_fact:
-    __tomcat_native_unpacked_dir: "{{tomcat_instance_path}}/bin/tomcat-native-{{ tomcat_version_specific[tomcat_version].tomcat_native_version }}-src"
+    __tomcat_native_unpacked_dir: "{{tomcat_instance_path}}/bin/tomcat-native-{{ tomcat_version_specific[tomcat_version].tomcat_native_version }}-src/jni/native"
 
 - debug: var=__tomcat_native_unpacked_dir
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -197,10 +197,11 @@
   stat:
     path: "{{ __tomcat_native_unpacked_dir }}"
   register: __tomcat_apr_dir
+  when: "{{ tomcat_use_apr }}"
 
 
 - name: Install Apache Portable Runtime Integration
-  when: not __tomcat_apr_dir.stat.exists
+  when: tomcat_use_apr and not __tomcat_apr_dir.stat.exists
   unarchive:
     remote_src: yes
     src: "{{ tomcat_instance_path }}/bin/tomcat-native.tar.gz"
@@ -209,7 +210,7 @@
 
 
 - name: Configure APR
-  when: not __tomcat_apr_dir.stat.exists
+  when: tomcat_use_apr and not __tomcat_apr_dir.stat.exists
   register: __tomcat_apr_configure
   command: >
     ./configure
@@ -222,11 +223,12 @@
 - name: Debug Output of APR Configure
   debug: var=__tomcat_apr_configure.stdout_lines
   when:
+    - tomcat_use_apr
     - tomcat_debug
     - not __tomcat_apr_dir.stat.exists
 
 - name: Make APR
-  when: not __tomcat_apr_dir.stat.exists
+  when: tomcat_use_apr and not __tomcat_apr_dir.stat.exists
   register: __tomcat_apr_make
   make:
     chdir: "{{ __tomcat_native_unpacked_dir }}"
@@ -238,7 +240,7 @@
     - not __tomcat_apr_dir.stat.exists
 
 - name: Make Install APR
-  when: not __tomcat_apr_dir.stat.exists
+  when: tomcat_use_apr and not __tomcat_apr_dir.stat.exists
   register: __tomcat_apr_make_install
   make:
     chdir: "{{ __tomcat_native_unpacked_dir }}"
@@ -248,6 +250,7 @@
 - name: Debug Output of Make Install APR
   debug: var=__tomcat_apr_make_install.stdout_lines
   when:
+    - tomcat_use_apr
     - tomcat_debug
     - not __tomcat_apr_dir.stat.exists
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -198,7 +198,7 @@
 
 - name: Set Unpacked Dir Location
   set_fact:
-    __tomcat_native_unpacked_dir: "{{tomcat_instance_path}}/bin/tomcat-native-{{ tomcat_version_specific[tomcat_version].tomcat_native_version }}-src/jni/native"
+    __tomcat_native_unpacked_dir: "{{tomcat_instance_path}}/bin/tomcat-native-{{ tomcat_version_specific[tomcat_version].tomcat_native_version }}-src/native"
 
 - debug: var=__tomcat_native_unpacked_dir
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -212,7 +212,11 @@
   when: not __tomcat_apr_dir.stat.exists
   register: __tomcat_apr_configure
   command: >
-    ./configure --with-apr=/usr/local/apr --with-java-home={{ java_home }}
+    ./configure
+    --with-apr=/usr/local/apr
+    --with-java-home={{ java_home }}
+    --with-ssl={{ openssl_install_location }}
+    --prefix={{ tomcat_catalina_home }}
     chdir={{ __tomcat_native_unpacked_dir }}
 
 - name: Debug Output of APR Configure

--- a/templates/tomcat.conf.j2
+++ b/templates/tomcat.conf.j2
@@ -6,7 +6,9 @@ description "Tomcat Server"
   respawn limit 10 5
 
   env JAVA_HOME={{ java_home }}
+  env CATALINA_BASE={{ tomcat_catalina_home }}
   env CATALINA_HOME={{ tomcat_catalina_home }}
+  env LD_LIBRARY_PATH=$LD_LIBRARY_PATH:{{ apr_install_location }}/lib:{{ tomcat_catalina_home}}/lib'
 
   {% if tomcat_java_opts not in (None, "") %}
   env JAVA_OPTS={{ tomcat_java_opts }}

--- a/templates/tomcat.service.j2
+++ b/templates/tomcat.service.j2
@@ -10,7 +10,7 @@ Environment='TOMCAT_JAVA_HOME={{ java_home }}'
 
 Environment='CATALINA_HOME={{ tomcat_catalina_home }}'
 Environment='CATALINA_BASE={{ tomcat_catalina_home }}'
-Environment='LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/apr/lib:{{ tomcat_catalina_home}}/lib'
+Environment='LD_LIBRARY_PATH=$LD_LIBRARY_PATH:{{ apr_install_location }}/lib:{{ tomcat_catalina_home}}/lib'
 
 {% if tomcat_catalina_opts not in (None, "") %}
 Environment='CATALINA_OPTS={{ tomcat_catalina_opts }}'

--- a/templates/tomcat.service.j2
+++ b/templates/tomcat.service.j2
@@ -10,7 +10,7 @@ Environment='TOMCAT_JAVA_HOME={{ java_home }}'
 
 Environment='CATALINA_HOME={{ tomcat_catalina_home }}'
 Environment='CATALINA_BASE={{ tomcat_catalina_home }}'
-Environment='LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/apr/lib'
+Environment='LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/apr/lib:{{ tomcat_catalina_home}}/lib'
 
 {% if tomcat_catalina_opts not in (None, "") %}
 Environment='CATALINA_OPTS={{ tomcat_catalina_opts }}'

--- a/templates/tomcat.service.j2
+++ b/templates/tomcat.service.j2
@@ -10,6 +10,7 @@ Environment='TOMCAT_JAVA_HOME={{ java_home }}'
 
 Environment='CATALINA_HOME={{ tomcat_catalina_home }}'
 Environment='CATALINA_BASE={{ tomcat_catalina_home }}'
+Environment='LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/apr/lib'
 
 {% if tomcat_catalina_opts not in (None, "") %}
 Environment='CATALINA_OPTS={{ tomcat_catalina_opts }}'

--- a/tests/no_apr.yml
+++ b/tests/no_apr.yml
@@ -2,12 +2,14 @@
 
 - hosts: localhost
   vars:
+    tomcat_use_apr: false
     test_user: tomcat
     tomcat_debug: true
     tomcat_users:
       - name: "{{ test_user }}"
         password: "{{ test_user }}"
         roles: "manager-gui,admin-gui"
+
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=yes

--- a/tests/test.retry
+++ b/tests/test.retry
@@ -1,1 +1,0 @@
-localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,6 +2,7 @@
 - hosts: localhost
   vars:
     test_user: tomcat
+    tomcat_debug: true
     tomcat_users:
       - name: "{{ test_user }}"
         password: "{{ test_user }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -29,4 +29,4 @@
     command: cat {{ tomcat_catalina_home }}/logs/catalina.out
     register: __tomcat_catalina_out
     changed_when: false
-  - debug: var=__tomcat_catalina_out
+  - debug: var=__tomcat_catalina_out.stdout_lines


### PR DESCRIPTION
Due to deficiencies in Centos 7/OEL 7 I either need to create an openssl role or this is a difficult problem to solve.

Basically we need greater than 1.0.2 and that update has not occured on those distros through any normal release channels. Fedora works, so the fix is coming but its not here now.

Perhaps an APR boolean for these distros?