### PR TITLE
Optional Java Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ None
 Role Dependencies
 -----------------
 
-[ChristopherDavenport.universal-java](https://galaxy.ansible.com/ChristopherDavenport/universal-java/)  
+[ChristopherDavenport.universal-java](https://galaxy.ansible.com/ChristopherDavenport/universal-java/) - Contingent on `tomcat_use_java` variable. **If this is set to false java_home variable will need to be provided**
+
 [ChristopherDavenport.apache-portable-runtime](https://galaxy.ansible.com/ChristopherDavenport/apache-portable-runtime/) - Contingent on `tomcat_use_apr` variable.
 
 
@@ -41,6 +42,11 @@ tomcat_mirrors:
 
 # Temporary Storage Directory
 tomcat_tmp_storage: /tmp/tomcat-ansible
+
+# Variable That Decides Installation of Dependency Java
+# If Not Present Through This role variable java_home will
+# need to be provided
+tomcat_use_java: true
 
 # Variable That Decides To Install the APR Role Dependency
 tomcat_use_apr: true

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ None
 Role Dependencies
 -----------------
 
-[ChristopherDavenport.universal-java](https://galaxy.ansible.com/ChristopherDavenport/universal-java/) - Contingent on `tomcat_use_java` variable. **If this is set to false java_home variable will need to be provided**
+[ChristopherDavenport.universal-java](https://galaxy.ansible.com/ChristopherDavenport/universal-java/) - Contingent on `tomcat_use_java` variable. **If this is set to false `java_home` variable will need to be provided**
 
 [ChristopherDavenport.apache-portable-runtime](https://galaxy.ansible.com/ChristopherDavenport/apache-portable-runtime/) - Contingent on `tomcat_use_apr` variable.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,11 @@ tomcat_mirrors:
 # Temporary Storage Directory
 tomcat_tmp_storage: /tmp/tomcat-ansible
 
+# Variable That Decides Installation of Dependency Java
+# If Not Present Through This role variable java_home will
+# need to be provided
+tomcat_use_java: true
+
 # Variable That Decides To Install the APR Role Dependency
 tomcat_use_apr: true
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,5 +29,7 @@ galaxy_info:
 
 
 dependencies:
-  - ChristopherDavenport.universal-java
-  - { role: ChristopherDavenport.apache-portable-runtime, when: tomcat_use_apr }
+  - role: ChristopherDavenport.universal-java
+    when: tomcat_use_java
+  - role: ChristopherDavenport.apache-portable-runtime
+    when: tomcat_use_apr


### PR DESCRIPTION
We had a concern about directly depending on the universal java role, this can now be relaxed using optional dependency variables. 

If you disable the dependency with 

```yaml
tomcat_use_java: false
java_home: YOUR_JAVA_HOME_HERE
```

Very happy to have found this ansible role feature to help users.