### PR TITLE
Adding options to remove web app Root Context

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,6 +79,9 @@ tomcat_configure_webapps: "{{ tomcat_configure }}"
 tomcat_extra_libs_path: []
 tomcat_webapps_path: []
 
+#Removes ROOT webapp Context if false
+tomcat_root_context: true
+
 # Strings That Allow you to modify your
 # tomcat instance in a predictable fashion.
 tomcat_extra_global_naming_resources: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -177,6 +177,13 @@
     group: "{{ tomcat_user_group }}"
     mode: 0640
 
+- name: Remove ROOT Webapp Context
+  file:
+    state: absent
+    path: "{{ tomcat_instance_path }}/webapps/ROOT/"
+  when:
+    - not tomcat_root_context
+
 - name: Install WebApps
   register: __tomcat_install_webapps
   with_items: "{{ tomcat_webapps_path }}"


### PR DESCRIPTION
Adding options to remove web app Root Context before custom web-app installed, in case web-app is named ROOT intentionally 