### PR TITLE
Update include statements

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -190,8 +190,7 @@
     mode: 0755
 
 - name: Install APR
-  include: apr.yml
-  static: true
+  import_tasks: apr.yml
   when: tomcat_use_apr
 
 - name: Check if systemd is present
@@ -200,9 +199,9 @@
   register: __stat_init
 
 - name: Install Tomcat Service with systemd
-  include: service_systemd_tomcat.yml
+  include_tasks: service_systemd_tomcat.yml
   when: __stat_init.stat.islnk and ( __stat_init.stat.lnk_source is defined ) and ( "systemd" in __stat_init.stat.lnk_source )
 
 - name: Install Tomcat Service with initctl
-  include: service_ctl_tomcat.yml
+  include_tasks: service_ctl_tomcat.yml
   when: not __stat_init.stat.islnk


### PR DESCRIPTION
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions.
This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.